### PR TITLE
Modularize formatter to be composable with other reporters.

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -51,12 +51,19 @@ function formatTest(name, result) {
     console.log(`##teamcity[testFinished name='${escapedTestName}' duration='${time}']`);
 }
 
-module.exports = {
-    write(result, options, done) {
-        const testSuites = result.modules;
-
-        Object.keys(testSuites).forEach( name => formatTestSuite(name, testSuites[name]) );
-
+function format(result, done) {
+    const testSuites = result.modules;
+    Object.keys(testSuites).forEach(name =>
+        formatTestSuite(name, testSuites[name])
+    );
+    if (done) {
         done();
     }
+}
+
+module.exports = {
+    write(result, options, done) {
+        format(result, done);
+    },
+    format: format
 };


### PR DESCRIPTION
My team was looking for a way to compose nightwatch-teamcity with another reporter (nightwatch-html-reporter) and we were able to do so by exporting some additional functionality from nightwatch-teamcity.

Use Example: 

```
// nightwatch-reporter.js

var HtmlReporter = require("nightwatch-html-reporter");
var teamCityFormatter = require("nightwatch-teamcity").format;

var reporter = new HtmlReporter({
  reportsDirectory: "./reports",
});

module.exports = {
  write: function(results, options, done) {
    teamCityFormatter(results);
    reporter.fn(results, done);
  }
};

```
```
$ nightwatch --reporter ./nightwatch-reporter.js
```

We thought this could come in handy for others. Thanks!